### PR TITLE
Provide human readable errors for TOML parsing

### DIFF
--- a/bin/calendar-assistant
+++ b/bin/calendar-assistant
@@ -8,6 +8,7 @@ Encoding.default_internal = Encoding::UTF_8
 Rainbow.enabled = true
 
 begin
+  require "calendar_assistant/cli"
   CalendarAssistant::CLI::Commands.start ARGV
 rescue Google::Apis::AuthorizationError, CalendarAssistant::BaseException => e
   printf "ERROR: %s\n", e

--- a/lib/calendar_assistant.rb
+++ b/lib/calendar_assistant.rb
@@ -42,5 +42,3 @@ class CalendarAssistant
   autoload :PredicateCollection, "calendar_assistant/predicate_collection"
   autoload :LocationConfigValidator, "calendar_assistant/location_config_validator"
 end
-
-require "calendar_assistant/cli"

--- a/lib/calendar_assistant/cli/config.rb
+++ b/lib/calendar_assistant/cli/config.rb
@@ -20,7 +20,7 @@ class CalendarAssistant
                           FileUtils.chmod 0600, config_file_path
                           TOML.load_file config_file_path
                         rescue Exception => e
-                          raise TomlParseFailure, "could not parse #{config_file_path}: #{e}"
+                          raise TomlParseFailure, "could not parse TOML file '#{config_file_path}': #{e}"
                         end
                       else
                         Hash.new

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,26 @@
 require "simplecov"
+require 'tmpdir'
 
 SimpleCov.start do
   add_filter "/spec/"
 end
 
 require_relative "../lib/calendar_assistant"
+
+def use_clean_config
+  temp_home_dir = Dir.mktmpdir
+  ENV["CA_HOME"] = temp_home_dir
+
+  yield
+
+  FileUtils.remove_entry temp_home_dir
+end
+
+# CLI::Commands reads local config to generate help and options
+use_clean_config do
+  require_relative "../lib/calendar_assistant/cli"
+end
+
 require_relative "./helpers/event_factory"
 require_relative "./shared_examples/a_configuration_class"
 require_relative "./shared_examples/an_object_that_has_duration"


### PR DESCRIPTION
The failure here is that the TOML config is read during the require phase of calendar assistant because of the way that Thor loads its configuration. 

So even though the CLI appeared to be used in a block that catches `CalendarAssistant::BaseException` and it was correctly throwing a `TomlParseFailure` it wasn't being caught.
