### PR TITLE
zoom links can be in conference data too

### DIFF
--- a/lib/calendar_assistant/event.rb
+++ b/lib/calendar_assistant/event.rb
@@ -192,6 +192,10 @@ class CalendarAssistant
 
     def av_uri
       @av_uri ||= begin
+        if conference_data && conference_data.conference_solution.name == "Zoom Meeting"
+          return conference_data.entry_points.detect{|d| d.entry_point_type == "video" }.uri
+        end
+
         description_link = CalendarAssistant::StringHelpers.find_uri_for_domain(description, "zoom.us")
         return description_link if description_link
 

--- a/spec/calendar_assistant/event_spec.rb
+++ b/spec/calendar_assistant/event_spec.rb
@@ -592,6 +592,31 @@ describe CalendarAssistant::Event do
     end
 
     describe "av_uri" do
+      context "there's conference data" do
+        let(:entry_point) { double(:entry_point, entry_point_type: "video", uri: "https://company.zoom.us/j/123412341") }
+        let(:conference_data) { double(:conference_data, conference_solution: conference_solution , entry_points: [ entry_point ] ) }
+
+        let(:decorated_object) do
+          decorated_class.new( conference_data: conference_data)
+        end
+
+        context "and it's for a zoom conference" do
+          let(:conference_solution) { double(:conference_solution, name: "Zoom Meeting") }
+
+          it "returns the URI" do
+            expect(subject.av_uri).to eq("https://company.zoom.us/j/123412341")
+          end
+        end
+
+        context "and it's for some other conference solution" do
+          let(:conference_solution) { double(:conference_solution, name: "Pan Meeting") }
+
+          it "returns the nil" do
+            expect(subject.av_uri).to be_nil
+          end
+        end
+      end
+
       context "location has a zoom link" do
         let(:decorated_object) do
           decorated_class.new location: "zoom at https://company.zoom.us/j/123412341 please", hangout_link: nil


### PR DESCRIPTION
This extension: [Zoom for Google Calendar](https://gsuite.google.com/marketplace/app/zoom_for_google_calendar/364750910244), unlike [Zoom Scheduler](https://chrome.google.com/webstore/detail/zoom-scheduler/kgjfgplpablkjnlkjmjdecgdpfankdle?hl=en-US) adds ConferenceSolution metadata to an event that looks like this:

![image](https://user-images.githubusercontent.com/1176640/54791327-9b3cc580-4bf6-11e9-92db-4dd62fda7116.png)

This pull request adds the ability to read that metadata and allows `join` to work as expected.