### PR TITLE
handle profile names that are email addresses

### DIFF
--- a/.github/workflows/test-suite.yml
+++ b/.github/workflows/test-suite.yml
@@ -19,6 +19,6 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Run test suite
-      run: bundle exec ./ci/run.sh
+      run: ./ci/run.sh
       env:
         CC_TEST_REPORTER_ID: ${{ secrets.CODE_CLIMATE_REPORTER_ID }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for Calendar Assistant
 
+## next / unreleased
+
+Dependencies:
+
+- move to `toml-rb` to support profile names that are email addresses [#188]
+
+
 ## v0.14.0 / 2021-02-24
 
 Dependencies:

--- a/README.md
+++ b/README.md
@@ -572,7 +572,6 @@ The output is TOML, which is suitable for dumping into `~/.calendar-assistant` a
 
 <pre>
 <b>$</b> calendar-assistant config
-
 [settings]
 end-of-day = "6pm"
 location-icon = "🌎"

--- a/calendar-assistant.gemspec
+++ b/calendar-assistant.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "launchy", "~> 2.4"
   spec.add_dependency "rainbow", "~> 3.0"
   spec.add_dependency "thor", "~> 1.1.0"
-  spec.add_dependency "toml", "~> 0.2.0"
+  spec.add_dependency "toml-rb", "~> 2.0.1"
   spec.add_dependency "thor_repl", "~> 0.1.4"
 
   spec.add_development_dependency "aruba", "~> 1.0.0"

--- a/lib/calendar_assistant.rb
+++ b/lib/calendar_assistant.rb
@@ -14,7 +14,7 @@ autoload :Chronic, "chronic"
 autoload :ChronicDuration, "chronic_duration"
 autoload :Google, "calendar_assistant/extensions/google_apis_extensions"
 autoload :Launchy, "calendar_assistant/extensions/launchy_extensions"
-autoload :TOML, "toml"
+autoload :TomlRB, "toml-rb"
 autoload :Thor, "thor"
 require "calendar_assistant/extensions/rainbow_extensions" # Rainbow() doesn't trigger autoload
 require "active_support/time" # Time doesn't trigger autoload

--- a/lib/calendar_assistant/cli/commands.rb
+++ b/lib/calendar_assistant/cli/commands.rb
@@ -66,7 +66,8 @@ class CalendarAssistant
       def config
         return if handle_help_args
         settings = CalendarAssistant::CLI::Config.new.settings
-        command_service.out.puts TomlRB.dump({ CalendarAssistant::Config::Keys::SETTINGS => settings })
+        filtered_settings = settings.reject { |k, v| v.nil? }
+        command_service.out.puts TomlRB.dump({ CalendarAssistant::Config::Keys::SETTINGS => filtered_settings })
       end
 
       desc "setup",

--- a/lib/calendar_assistant/cli/commands.rb
+++ b/lib/calendar_assistant/cli/commands.rb
@@ -66,7 +66,7 @@ class CalendarAssistant
       def config
         return if handle_help_args
         settings = CalendarAssistant::CLI::Config.new.settings
-        command_service.out.puts TOML::Generator.new({ CalendarAssistant::Config::Keys::SETTINGS => settings }).body
+        command_service.out.puts TomlRB.dump({ CalendarAssistant::Config::Keys::SETTINGS => settings })
       end
 
       desc "setup",

--- a/lib/calendar_assistant/cli/config.rb
+++ b/lib/calendar_assistant/cli/config.rb
@@ -18,7 +18,7 @@ class CalendarAssistant
         user_config = if File.exist? config_file_path
                         begin
                           FileUtils.chmod 0600, config_file_path
-                          TOML.load_file config_file_path
+                          TomlRB.load_file config_file_path
                         rescue Exception => e
                           raise TomlParseFailure, "could not parse TOML file '#{config_file_path}': #{e}"
                         end
@@ -39,7 +39,7 @@ class CalendarAssistant
           raise NoConfigFileToPersist, "Cannot persist config when there's no config file"
         end
 
-        content = TOML::Generator.new(user_config).body
+        content = TomlRB.dump(user_config)
 
         File.open(config_file_path, "w") do |f|
           f.write content

--- a/spec/calendar_assistant/cli/commands_spec.rb
+++ b/spec/calendar_assistant/cli/commands_spec.rb
@@ -65,10 +65,10 @@ describe CalendarAssistant::CLI::Commands do
     let(:command) { "config" }
     it_behaves_like "a command"
 
-    it "prints out config settings" do
+    it "prints out config settings without unset settings" do
       expect(CalendarAssistant::Config).to receive(:new).with(no_args).and_return(config)
-      expect(config).to receive(:settings).and_return({ "my" => "settings" })
-      allow(TomlRB).to receive(:dump).with({ CalendarAssistant::Config::Keys::SETTINGS => { "my" => "settings" } }).and_return("body")
+      expect(config).to receive(:settings).and_return({ "configured" => "setting", "unconfigured" => nil })
+      allow(TomlRB).to receive(:dump).with({ CalendarAssistant::Config::Keys::SETTINGS => { "configured" => "setting" } }).and_return("body")
       expect(out).to receive(:puts).with("body")
 
       described_class.start [command]

--- a/spec/calendar_assistant/cli/commands_spec.rb
+++ b/spec/calendar_assistant/cli/commands_spec.rb
@@ -65,13 +65,10 @@ describe CalendarAssistant::CLI::Commands do
     let(:command) { "config" }
     it_behaves_like "a command"
 
-    let(:generator) { instance_double(TOML::Generator) }
-
     it "prints out config settings" do
       expect(CalendarAssistant::Config).to receive(:new).with(no_args).and_return(config)
       expect(config).to receive(:settings).and_return({ "my" => "settings" })
-      allow(TOML::Generator).to receive(:new).with({ CalendarAssistant::Config::Keys::SETTINGS => { "my" => "settings" } }).and_return(generator)
-      expect(generator).to receive(:body).and_return("body")
+      allow(TomlRB).to receive(:dump).with({ CalendarAssistant::Config::Keys::SETTINGS => { "my" => "settings" } }).and_return("body")
       expect(out).to receive(:puts).with("body")
 
       described_class.start [command]

--- a/spec/calendar_assistant/cli/config_spec.rb
+++ b/spec/calendar_assistant/cli/config_spec.rb
@@ -6,7 +6,7 @@ describe CalendarAssistant::CLI::Config do
   let(:args) { { config_file_path: temp_config_file.path } }
 
   before(:each) do
-    File.open(temp_config_file.path, "w") { |f| f.write(TOML::Generator.new(user_config).body) }
+    File.open(temp_config_file.path, "w") { |f| f.write(TomlRB.dump(user_config)) }
   end
 
   it_behaves_like "a configuration class"

--- a/spec/shared_examples/a_configuration_class.rb
+++ b/spec/shared_examples/a_configuration_class.rb
@@ -65,6 +65,23 @@ shared_examples_for "a configuration class" do
           new_config = described_class.new(**args)
           expect(new_config.get([described_class::Keys::SETTINGS, described_class::Keys::Settings::PROFILE])).to eq("arbeit")
         end
+
+        context "with an embedded period" do
+          let(:user_config) do
+            {
+              "tokens" => {
+                "foo@bar.com" => "fake-token-1",
+              }
+            }
+          end
+
+          it { expect(subject.profile_name).to eq("foo@bar.com") }
+
+          context "a profile is specified via options" do
+            let(:options) { { "profile" => "foo@bar.com" } }
+            it { expect(subject.profile_name).to eq("foo@bar.com") }
+          end
+        end
       end
     end
 


### PR DESCRIPTION
The gem we've been using, `toml`, doesn't support keys that aren't "bare words" (see https://toml.io/en/v1.0.0#keys). Let's use a TOML parser/generator that does.

Fixes #188