### PR TITLE
wip: add a `--tz` option to the `avail` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Options:
   -l, [--local-store=FILENAME]                     # Load events from a local file instead of Google Calendar
   -b, [--must-be=PROPERTY1[,PROPERTY2[,...]]]      # Event properties that must be true (see README)
   -n, [--must-not-be=PROPERTY1[,PROPERTY2[,...]]]  # Event properties that must be false (see README)
+  -z, [--tz=TZNAME1[,TZNAME2[,...]]]               # Force display of only these time zones, ignoring calendar settings
   -h, -?, [--help], [--no-help]                    
           [--debug], [--no-debug]                  # how dare you suggest there are bugs
   -f, [--formatting], [--no-formatting]            # Enable Text Formatting
@@ -276,6 +277,7 @@ Options:
   -l, [--local-store=FILENAME]                                # Load events from a local file instead of Google Calendar
   -b, [--must-be=PROPERTY1[,PROPERTY2[,...]]]                 # Event properties that must be true (see README)
   -n, [--must-not-be=PROPERTY1[,PROPERTY2[,...]]]             # Event properties that must be false (see README)
+  -z, [--tz=TZNAME1[,TZNAME2[,...]]]                          # Force display of only these time zones, ignoring calendar settings
   -h, -?, [--help], [--no-help]                               
           [--debug], [--no-debug]                             # how dare you suggest there are bugs
   -f, [--formatting], [--no-formatting]                       # Enable Text Formatting
@@ -377,6 +379,7 @@ Options:
   -l, [--local-store=FILENAME]                                # Load events from a local file instead of Google Calendar
   -b, [--must-be=PROPERTY1[,PROPERTY2[,...]]]                 # Event properties that must be true (see README)
   -n, [--must-not-be=PROPERTY1[,PROPERTY2[,...]]]             # Event properties that must be false (see README)
+  -z, [--tz=TZNAME1[,TZNAME2[,...]]]                          # Force display of only these time zones, ignoring calendar settings
   -a, --attendees, [--calendars=CALENDAR1[,CALENDAR2[,...]]]  # [default 'me'] people (email IDs) to whom this command will be applied
   -h, -?, [--help], [--no-help]                               
           [--debug], [--no-debug]                             # how dare you suggest there are bugs
@@ -424,6 +427,7 @@ Options:
   -l, [--local-store=FILENAME]                     # Load events from a local file instead of Google Calendar
   -b, [--must-be=PROPERTY1[,PROPERTY2[,...]]]      # Event properties that must be true (see README)
   -n, [--must-not-be=PROPERTY1[,PROPERTY2[,...]]]  # Event properties that must be false (see README)
+  -z, [--tz=TZNAME1[,TZNAME2[,...]]]               # Force display of only these time zones, ignoring calendar settings
   -h, -?, [--help], [--no-help]                    
           [--debug], [--no-debug]                  # how dare you suggest there are bugs
   -f, [--formatting], [--no-formatting]            # Enable Text Formatting
@@ -456,6 +460,7 @@ Options:
   -a, --attendees, [--calendars=CALENDAR1[,CALENDAR2[,...]]]  # [default 'me'] people (email IDs) to whom this command will be applied
   -b, [--must-be=PROPERTY1[,PROPERTY2[,...]]]                 # Event properties that must be true (see README)
   -n, [--must-not-be=PROPERTY1[,PROPERTY2[,...]]]             # Event properties that must be false (see README)
+  -z, [--tz=TZNAME1[,TZNAME2[,...]]]                          # Force display of only these time zones, ignoring calendar settings
   -h, -?, [--help], [--no-help]                               
           [--debug], [--no-debug]                             # how dare you suggest there are bugs
   -f, [--formatting], [--no-formatting]                       # Enable Text Formatting
@@ -526,6 +531,7 @@ Options:
   -a, --attendees, [--calendars=CALENDAR1[,CALENDAR2[,...]]]  # [default 'me'] people (email IDs) to whom this command will be applied
   -b, [--must-be=PROPERTY1[,PROPERTY2[,...]]]                 # Event properties that must be true (see README)
   -n, [--must-not-be=PROPERTY1[,PROPERTY2[,...]]]             # Event properties that must be false (see README)
+  -z, [--tz=TZNAME1[,TZNAME2[,...]]]                          # Force display of only these time zones, ignoring calendar settings
   -h, -?, [--help], [--no-help]                               
           [--debug], [--no-debug]                             # how dare you suggest there are bugs
   -f, [--formatting], [--no-formatting]                       # Enable Text Formatting

--- a/lib/calendar_assistant/cli/commands.rb
+++ b/lib/calendar_assistant/cli/commands.rb
@@ -27,6 +27,11 @@ class CalendarAssistant
                desc: "Event properties that must be false (see README)",
                banner: "PROPERTY1[,PROPERTY2[,...]]",
                aliases: ["-n"]
+        option CalendarAssistant::Config::Keys::Options::TIME_ZONES,
+               type: :string,
+               desc: "Force display of only these time zones, ignoring calendar settings",
+               banner: "TZNAME1[,TZNAME2[,...]]",
+               aliases: ["-z"]
       end
 
       def self.has_multiple_calendars

--- a/lib/calendar_assistant/cli/printer.rb
+++ b/lib/calendar_assistant/cli/printer.rb
@@ -45,7 +45,7 @@ class CalendarAssistant
 
       def print_available_blocks(ca, event_set, omit_title: false)
         ers = ca.config.calendar_ids.map { |calendar_id| ca.event_repository calendar_id }
-        time_zones = ers.map { |er| er.calendar.time_zone }.uniq
+        time_zones = ca.config.time_zones || ers.map { |er| er.calendar.time_zone }.uniq
 
         unless omit_title
           puts Rainbow(ers.map { |er| er.calendar.id }.join(", ")).italic

--- a/lib/calendar_assistant/config.rb
+++ b/lib/calendar_assistant/config.rb
@@ -42,6 +42,7 @@ class CalendarAssistant
         MUST_NOT_BE = "must-not-be" # array of event predicates (comma-delimited)
         CONTEXT = "context"         # symbol referring to command context
         FORCE = "force"             # bool
+        TIME_ZONES = "tz"           # array of time zone names (comma-delimited)
       end
     end
 
@@ -162,6 +163,10 @@ class CalendarAssistant
 
     def debug?
       setting(Keys::Options::DEBUG)
+    end
+
+    def time_zones
+      split_if_array(Keys::Options::TIME_ZONES)
     end
 
     def persist!


### PR DESCRIPTION
Related to #191

This adds a `--tz` option to allow the output format to be in one (or more) specific timezones, rather than the calendar timezones.

Things that still need work:

- [ ] the option should either only be available on commands that respect it, or all commands need to respect it
- [ ] need to add some tests
