### PR TITLE
quash deprecation warning from active support 7.2

### DIFF
--- a/bin/calendar-assistant
+++ b/bin/calendar-assistant
@@ -6,6 +6,9 @@ require "calendar_assistant"
 
 Encoding.default_internal = Encoding::UTF_8
 Rainbow.enabled = true
+if ActiveSupport.respond_to?(:to_time_preserves_timezone)
+  ActiveSupport.to_time_preserves_timezone = true
+end
 
 begin
   require "calendar_assistant/cli"


### PR DESCRIPTION
> DEPRECATION WARNING: to_time will always preserve the timezone offset of the receiver in Rails 8.0. To opt in to the new behavior, set `ActiveSupport.to_time_preserves_timezone = true`. (called from block (3 levels) in available_blocks at /home/runner/work/calendar-assistant/calendar-assistant/lib/calendar_assistant/event_set.rb:87)

See https://github.com/flavorjones/calendar-assistant/actions/runs/10416770277/job/28849661106#step:4:74 for example failure